### PR TITLE
make `getMinVersion` optional

### DIFF
--- a/changelog/@unreleased/pr-21.v2.yml
+++ b/changelog/@unreleased/pr-21.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: make `getMinVersion` optional
+  links:
+  - https://github.com/palantir/gradle-idea-configuration/pull/21

--- a/gradle-idea-configuration/src/main/groovy/com/palantir/gradle/ideaconfiguration/PluginDependency.java
+++ b/gradle-idea-configuration/src/main/groovy/com/palantir/gradle/ideaconfiguration/PluginDependency.java
@@ -24,6 +24,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 
 public abstract class PluginDependency implements Named {
     private static final Pattern DOT_SPLITTER = Pattern.compile("\\.");
@@ -35,6 +36,7 @@ public abstract class PluginDependency implements Named {
     @Override
     public abstract String getName();
 
+    @Optional
     @Input
     public final Provider<String> getMinVersion() {
         return getMinRequiredVersions().map(requiredMinVersions -> requiredMinVersions.stream()

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPluginIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPluginIntegrationSpec.groovy
@@ -299,7 +299,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         buildFile << """
              ideaConfiguration {
                 externalDependencies {
-                    'test'
+                    'test' {}
                 }
             }
         """.stripIndent(true)
@@ -336,4 +336,32 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         assert externalDepsFile.text.trim() == expected
     }
 
+    def "can add if no minimum version provided"() {
+        //language=gradle
+        buildFile << """
+            ideaConfiguration {
+                externalDependencies {
+                    'test' {}
+                }
+            }
+        """.stripIndent(true)
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we generate the correct config'
+        def externalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
+        externalDepsFile.exists()
+
+        //language=xml
+        def expected = """
+          <project version="4">
+            <component name="ExternalDependencies">
+              <plugin id="test"/>
+            </component>
+          </project>
+        """.stripIndent(true).trim()
+
+        assert externalDepsFile.text.trim() == expected
+    }
 }


### PR DESCRIPTION
## Before this PR
`getMinVersion` was not optional so if it was not set it would cause the foillowing:

```
A problem was found with the configuration of task ':updateExternalDepsXml' (type 'UpdateExternalDependenciesXml').
  - In plugin 'com.palantir.gradle.ideaconfiguration.IdeaConfigurationPlugin' type 'com.palantir.gradle.ideaconfiguration.UpdateExternalDependenciesXml' property 'dependencies.CheckStyle-IDEA$0.minVersion' doesn't have a configured value.
    
    Reason: This property isn't marked as optional and no value has been configured.
    
    Possible solutions:
      1. The value of 'dependencies.CheckStyle-IDEA$0.minVersion' is calculated, make sure a valid value can be calculated.
      2. Mark property 'dependencies.CheckStyle-IDEA$0.minVersion' as optional.
    
    For more information, please refer to https://docs.gradle.org/8.12.1/userguide/validation_problems.html#value_not_set in the Gradle documentation.
```

## After this PR
Now the input is optional and a test has been added to prevent regression
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
make `getMinVersion` optional
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

