### PR TITLE
Support modifications to the `.idea/IntelliLang.xml` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,26 @@ ideaConfiguration {
     }
 }
 ```
+
+### Language Injections
+
+Configure IntelliJ language injections for your code. This is useful when you have methods that accept string parameters containing code in other languages (SQL, HTML, RegExp, etc.).
+
+```gradle
+ideaConfiguration {
+    languageInjections {
+        'sql-executor' {
+            language = 'SQL'
+            displayName = 'SqlExecutor.execute (com.example)'
+            pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+        }
+        'html-renderer' {
+            language = 'HTML'
+            displayName = 'HtmlRenderer.render (com.example)'
+            pattern = 'psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))'
+        }
+    }
+}
+```
+
+The plugin will automatically update `.idea/IntelliLang.xml` with your configured injections.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ ideaConfiguration {
 
 ### Language Injections
 
-Configure IntelliJ language injections for your code. This is useful when you have methods that accept string parameters containing code in other languages (SQL, HTML, RegExp, etc.).
-
+Configure IntelliJ language injections for your code. 
 ```gradle
 ideaConfiguration {
     languageInjections {

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ ideaConfiguration {
         'sql-executor' {
             language = 'SQL'
             displayName = 'SqlExecutor.execute (com.example)'
-            pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+            patterns = ['psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))']
         }
         'html-renderer' {
             language = 'HTML'
             displayName = 'HtmlRenderer.render (com.example)'
-            pattern = 'psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))'
+            patterns = ['psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))']
         }
     }
 }

--- a/gradle-idea-configuration/build.gradle
+++ b/gradle-idea-configuration/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+    implementation 'com.palantir.gradle.better-exec:better-exec'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/gradle-idea-configuration/build.gradle
+++ b/gradle-idea-configuration/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
-    implementation 'com.palantir.gradle.better-exec:better-exec'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/IdeaConfigurationExtension.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/IdeaConfigurationExtension.java
@@ -21,6 +21,8 @@ import org.gradle.api.NamedDomainObjectContainer;
 public abstract class IdeaConfigurationExtension {
     public abstract NamedDomainObjectContainer<PluginDependency> getExternalDependencies();
 
+    public abstract NamedDomainObjectContainer<LanguageInjection> getLanguageInjections();
+
     @SuppressWarnings("for-rollout:ConfigurationAvoidanceRegistration")
     @Deprecated(forRemoval = true)
     public final void externalDependency(String name) {

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPlugin.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPlugin.java
@@ -39,15 +39,21 @@ public class IdeaConfigurationPlugin implements Plugin<Project> {
             return;
         }
 
-        TaskProvider<UpdateExternalDependenciesXml> updateTask = project.getTasks()
+        TaskProvider<UpdateExternalDependenciesXml> updateExternalDepsTask = project.getTasks()
                 .register("updateExternalDepsXml", UpdateExternalDependenciesXml.class, task -> {
                     task.getDependencies().set(extension.getExternalDependencies());
                 });
 
-        // Add the task to the Gradle start parameters so it executes automatically.
+        TaskProvider<UpdateIntelliLangXml> updateIntelliLangTask = project.getTasks()
+                .register("updateIntelliLangXml", UpdateIntelliLangXml.class, task -> {
+                    task.getInjections().set(extension.getLanguageInjections());
+                });
+
+        // Add the tasks to the Gradle start parameters so they execute automatically.
         StartParameter startParameter = project.getGradle().getStartParameter();
         List<String> taskNames = new ArrayList<>(startParameter.getTaskNames());
-        taskNames.add(":" + updateTask.getName());
+        taskNames.add(":" + updateExternalDepsTask.getName());
+        taskNames.add(":" + updateIntelliLangTask.getName());
         startParameter.setTaskNames(taskNames);
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPlugin.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPlugin.java
@@ -35,7 +35,7 @@ public class IdeaConfigurationPlugin implements Plugin<Project> {
         IdeaConfigurationExtension extension =
                 project.getExtensions().create("ideaConfiguration", IdeaConfigurationExtension.class);
 
-        if (!Boolean.getBoolean("idea.active")) {
+        if (!Boolean.getBoolean("idea.active") || !Boolean.getBoolean("idea.sync.active")) {
             return;
         }
 

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration;
+
+import java.io.Serializable;
+import javax.inject.Inject;
+import org.gradle.api.Named;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+
+/**
+ * Represents a language injection configuration for IntelliJ IDEA.
+ */
+public abstract class LanguageInjection implements Named, Serializable {
+    private final String name;
+
+    @Inject
+    public LanguageInjection(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of this language injection.
+     */
+    @Override
+    @Internal
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The language ID for the injection (e.g., "SQL", "HTML", "RegExp").
+     */
+    @Input
+    public abstract Property<String> getLanguage();
+
+    /**
+     * The display name shown in IntelliJ (optional).
+     */
+    @Input
+    @Optional
+    public abstract Property<String> getDisplayName();
+
+    /**
+     * The PSI pattern that defines where the language should be injected. Example:
+     * psiParameter().ofMethod(0,
+     * psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.Executor"))
+     */
+    @Input
+    public abstract Property<String> getPattern();
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
@@ -57,8 +57,8 @@ public abstract class LanguageInjection implements Named, Serializable {
 
     /**
      * The PSI pattern that defines where the language should be injected. Example:
-     * psiParameter().ofMethod(0,
-     * psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.Executor"))
+     * psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String")
+     * .definedInClass("com.example.Executor"))
      */
     @Input
     public abstract Property<String> getPattern();

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.ideaconfiguration;
 import java.io.Serializable;
 import javax.inject.Inject;
 import org.gradle.api.Named;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -56,10 +57,10 @@ public abstract class LanguageInjection implements Named, Serializable {
     public abstract Property<String> getDisplayName();
 
     /**
-     * The PSI pattern that defines where the language should be injected. Example:
+     * The PSI patterns that define where the language should be injected. Example:
      * psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String")
      * .definedInClass("com.example.Executor"))
      */
     @Input
-    public abstract Property<String> getPattern();
+    public abstract ListProperty<String> getPatterns();
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/LanguageInjection.java
@@ -22,7 +22,6 @@ import org.gradle.api.Named;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 
 /**
  * Represents a language injection configuration for IntelliJ IDEA.
@@ -51,10 +50,9 @@ public abstract class LanguageInjection implements Named, Serializable {
     public abstract Property<String> getLanguage();
 
     /**
-     * The display name shown in IntelliJ (optional).
+     * The display name shown in IntelliJ.
      */
     @Input
-    @Optional
     public abstract Property<String> getDisplayName();
 
     /**

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXml.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXml.java
@@ -34,7 +34,6 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -141,43 +140,6 @@ public abstract class UpdateIntelliLangXml extends DefaultTask {
                 .build();
     }
 
-    /**
-     * Composite key for uniquely identifying an injection by display name, language, and injector ID.
-     */
-    private static final class InjectionKey {
-        private final String displayName;
-        private final String language;
-        private final String injectorId;
-
-        private InjectionKey(String displayName, String language, String injectorId) {
-            this.displayName = displayName;
-            this.language = language;
-            this.injectorId = injectorId;
-        }
-
-        static InjectionKey from(IntelliLangInjection injection) {
-            return new InjectionKey(injection.displayName(), injection.language(), injection.injectorId());
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (!(obj instanceof InjectionKey other)) {
-                return false;
-            }
-            return Objects.equals(displayName, other.displayName)
-                    && Objects.equals(language, other.language)
-                    && Objects.equals(injectorId, other.injectorId);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(displayName, language, injectorId);
-        }
-    }
-
     private static IntelliLangProject createNewProject(List<IntelliLangInjection> injections) {
         // Merge injections with same composite key before creating project
         Map<InjectionKey, IntelliLangInjection> mergedMap = injections.stream()
@@ -208,6 +170,15 @@ public abstract class UpdateIntelliLangXml extends DefaultTask {
                     "Failed to write back to configuration file: "
                             + getOutputFile().get(),
                     e);
+        }
+    }
+
+    /**
+     * Composite key for uniquely identifying an injection by display name, language, and injector ID.
+     */
+    private record InjectionKey(String displayName, String language, String injectorId) {
+        static InjectionKey from(IntelliLangInjection injection) {
+            return new InjectionKey(injection.displayName(), injection.language(), injection.injectorId());
         }
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXml.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXml.java
@@ -1,0 +1,143 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+import com.ctc.wstx.stax.WstxOutputFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangComponent;
+import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangInjection;
+import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangProject;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class UpdateIntelliLangXml extends DefaultTask {
+    private static final Logger log = LoggerFactory.getLogger(UpdateIntelliLangXml.class);
+
+    private static final ObjectMapper XML_MAPPER = new XmlMapper(new WstxInputFactory(), new WstxOutputFactory())
+            .registerModule(new Jdk8Module())
+            .registerModule(new GuavaModule())
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    @Nested
+    public abstract SetProperty<LanguageInjection> getInjections();
+
+    @OutputFile
+    public abstract RegularFileProperty getOutputFile();
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
+
+    public UpdateIntelliLangXml() {
+        getOutputFile().set(getProjectLayout().getProjectDirectory().file(".idea/IntelliLang.xml"));
+    }
+
+    @TaskAction
+    public final void updateXml() {
+        Set<LanguageInjection> injections = getInjections().get();
+        File outputFile = getOutputFile().get().getAsFile();
+
+        if (injections.isEmpty()) {
+            log.info("No language injections found. Skipping update.");
+            return;
+        }
+
+        List<IntelliLangInjection> addedInjections = toIntelliLangInjections(injections);
+        IntelliLangProject updatedXml = readXml(outputFile)
+                .map(existingProject -> mergeInjectionsIntoXml(existingProject, addedInjections))
+                .orElseGet(() -> createNewProject(addedInjections));
+
+        writeXml(outputFile, updatedXml);
+    }
+
+    private static Optional<IntelliLangProject> readXml(File outputFile) {
+        if (!outputFile.exists()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(XML_MAPPER.readValue(outputFile, IntelliLangProject.class));
+        } catch (IOException e) {
+            log.error("Failed to parse existing configuration file: {}", outputFile, e);
+        }
+        return Optional.empty();
+    }
+
+    private static IntelliLangProject mergeInjectionsIntoXml(
+            IntelliLangProject existingProject, List<IntelliLangInjection> newInjections) {
+
+        List<IntelliLangInjection> existingInjections =
+                existingProject.component().injections();
+
+        List<IntelliLangInjection> mergedInjections = Stream.concat(existingInjections.stream(), newInjections.stream())
+                .collect(Collectors.toMap(
+                        // Use display name as the unique key
+                        IntelliLangInjection::displayName,
+                        injection -> injection,
+                        // If duplicate, keep the new one
+                        (_existing, replacement) -> replacement))
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(IntelliLangInjection::displayName))
+                .collect(Collectors.toList());
+
+        return IntelliLangProject.of(IntelliLangComponent.of(mergedInjections), existingProject.version());
+    }
+
+    private static IntelliLangProject createNewProject(List<IntelliLangInjection> injections) {
+        List<IntelliLangInjection> sortedInjections = injections.stream()
+                .sorted(Comparator.comparing(IntelliLangInjection::displayName))
+                .collect(Collectors.toList());
+        return IntelliLangProject.of(IntelliLangComponent.of(sortedInjections), "4");
+    }
+
+    private static List<IntelliLangInjection> toIntelliLangInjections(Set<LanguageInjection> injections) {
+        return injections.stream().map(IntelliLangInjection::from).collect(Collectors.toList());
+    }
+
+    private void writeXml(File outputFile, IntelliLangProject updatedXml) {
+        try {
+            outputFile.getParentFile().mkdirs();
+            XML_MAPPER.writeValue(outputFile, updatedXml);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to write back to configuration file: "
+                            + getOutputFile().get(),
+                    e);
+        }
+    }
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXml.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXml.java
@@ -25,12 +25,16 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangComponent;
 import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangInjection;
+import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangPlace;
 import com.palantir.gradle.ideaconfiguration.intellilang.IntelliLangProject;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -103,24 +107,90 @@ public abstract class UpdateIntelliLangXml extends DefaultTask {
         List<IntelliLangInjection> existingInjections =
                 existingProject.component().injections();
 
-        List<IntelliLangInjection> mergedInjections = Stream.concat(existingInjections.stream(), newInjections.stream())
+        // Use composite key: (displayName, language, injectorId)
+        Map<InjectionKey, IntelliLangInjection> mergedMap = Stream.concat(
+                        existingInjections.stream(), newInjections.stream())
                 .collect(Collectors.toMap(
-                        // Use display name as the unique key
-                        IntelliLangInjection::displayName,
+                        InjectionKey::from,
                         injection -> injection,
-                        // If duplicate, keep the new one
-                        (_existing, replacement) -> replacement))
-                .values()
-                .stream()
-                .sorted(Comparator.comparing(IntelliLangInjection::displayName))
+                        // If duplicate key, merge the places from both injections
+                        UpdateIntelliLangXml::mergeInjections,
+                        LinkedHashMap::new));
+
+        List<IntelliLangInjection> mergedInjections = mergedMap.values().stream()
+                .sorted(Comparator.comparing(IntelliLangInjection::displayName)
+                        .thenComparing(IntelliLangInjection::language)
+                        .thenComparing(IntelliLangInjection::injectorId))
                 .collect(Collectors.toList());
 
         return IntelliLangProject.of(IntelliLangComponent.of(mergedInjections), existingProject.version());
     }
 
+    private static IntelliLangInjection mergeInjections(
+            IntelliLangInjection existing, IntelliLangInjection replacement) {
+        // Combine places from both injections and remove duplicates
+        List<String> mergedPlaces = Stream.concat(existing.places().stream(), replacement.places().stream())
+                .map(IntelliLangPlace::pattern)
+                .distinct()
+                .sorted()
+                .toList();
+
+        return IntelliLangInjection.builder()
+                .from(existing)
+                .places(mergedPlaces.stream().map(IntelliLangPlace::of).collect(Collectors.toList()))
+                .build();
+    }
+
+    /**
+     * Composite key for uniquely identifying an injection by display name, language, and injector ID.
+     */
+    private static final class InjectionKey {
+        private final String displayName;
+        private final String language;
+        private final String injectorId;
+
+        private InjectionKey(String displayName, String language, String injectorId) {
+            this.displayName = displayName;
+            this.language = language;
+            this.injectorId = injectorId;
+        }
+
+        static InjectionKey from(IntelliLangInjection injection) {
+            return new InjectionKey(injection.displayName(), injection.language(), injection.injectorId());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof InjectionKey other)) {
+                return false;
+            }
+            return Objects.equals(displayName, other.displayName)
+                    && Objects.equals(language, other.language)
+                    && Objects.equals(injectorId, other.injectorId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(displayName, language, injectorId);
+        }
+    }
+
     private static IntelliLangProject createNewProject(List<IntelliLangInjection> injections) {
-        List<IntelliLangInjection> sortedInjections = injections.stream()
-                .sorted(Comparator.comparing(IntelliLangInjection::displayName))
+        // Merge injections with same composite key before creating project
+        Map<InjectionKey, IntelliLangInjection> mergedMap = injections.stream()
+                .collect(Collectors.toMap(
+                        InjectionKey::from,
+                        injection -> injection,
+                        UpdateIntelliLangXml::mergeInjections,
+                        LinkedHashMap::new));
+
+        List<IntelliLangInjection> sortedInjections = mergedMap.values().stream()
+                .sorted(Comparator.comparing(IntelliLangInjection::displayName)
+                        .thenComparing(IntelliLangInjection::language)
+                        .thenComparing(IntelliLangInjection::injectorId))
                 .collect(Collectors.toList());
         return IntelliLangProject.of(IntelliLangComponent.of(sortedInjections), "4");
     }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangComponent.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangComponent.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration.intellilang;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.util.List;
+import org.immutables.value.Value;
+
+/**
+ * Component element containing language injection configuration.
+ */
+@Value.Immutable
+@JsonDeserialize(as = ImmutableIntelliLangComponent.class)
+public interface IntelliLangComponent {
+
+    @JacksonXmlProperty(isAttribute = true)
+    @Value.Default
+    default String name() {
+        return "LanguageInjectionConfiguration";
+    }
+
+    @JacksonXmlProperty(localName = "injection")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    List<IntelliLangInjection> injections();
+
+    static ImmutableIntelliLangComponent.Builder builder() {
+        return ImmutableIntelliLangComponent.builder();
+    }
+
+    static IntelliLangComponent of(List<IntelliLangInjection> injections) {
+        return builder().injections(injections).build();
+    }
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangComponent.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangComponent.java
@@ -41,11 +41,7 @@ public interface IntelliLangComponent {
     @JacksonXmlElementWrapper(useWrapping = false)
     List<IntelliLangInjection> injections();
 
-    static ImmutableIntelliLangComponent.Builder builder() {
-        return ImmutableIntelliLangComponent.builder();
-    }
-
     static IntelliLangComponent of(List<IntelliLangInjection> injections) {
-        return builder().injections(injections).build();
+        return ImmutableIntelliLangComponent.builder().injections(injections).build();
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangComponent.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangComponent.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.ideaconfiguration.intellilang;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -27,6 +28,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(as = ImmutableIntelliLangComponent.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface IntelliLangComponent {
 
     @JacksonXmlProperty(isAttribute = true)

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
@@ -47,7 +47,7 @@ public interface IntelliLangInjection {
     @JacksonXmlProperty(localName = "single-file")
     @Value.Default
     default IntelliLangSingleFile singleFile() {
-        return ImmutableIntelliLangSingleFile.builder().build();
+        return IntelliLangSingleFile.defaultSingleFile();
     }
 
     @JacksonXmlProperty(localName = "place")
@@ -59,13 +59,9 @@ public interface IntelliLangInjection {
     }
 
     static IntelliLangInjection from(LanguageInjection injection) {
-        String displayName = injection.getDisplayName().isPresent()
-                ? injection.getDisplayName().get()
-                : injection.getName();
-
         return builder()
                 .language(injection.getLanguage().get())
-                .displayName(displayName)
+                .displayName(injection.getDisplayName().get())
                 .addPlaces(IntelliLangPlace.of(injection.getPattern().get()))
                 .build();
     }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
@@ -59,10 +59,14 @@ public interface IntelliLangInjection {
     }
 
     static IntelliLangInjection from(LanguageInjection injection) {
-        return builder()
+        ImmutableIntelliLangInjection.Builder builder = builder()
                 .language(injection.getLanguage().get())
-                .displayName(injection.getDisplayName().get())
-                .addPlaces(IntelliLangPlace.of(injection.getPattern().get()))
-                .build();
+                .displayName(injection.getDisplayName().get());
+
+        injection.getPatterns().get().forEach(pattern -> {
+            builder.addPlaces(IntelliLangPlace.of(pattern));
+        });
+
+        return builder.build();
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.ideaconfiguration.intellilang;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -28,6 +29,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(as = ImmutableIntelliLangInjection.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface IntelliLangInjection {
 
     @JacksonXmlProperty(isAttribute = true)

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
@@ -17,8 +17,10 @@
 package com.palantir.gradle.ideaconfiguration.intellilang;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.palantir.gradle.ideaconfiguration.LanguageInjection;
+import java.util.List;
 import org.immutables.value.Value;
 
 /**
@@ -47,7 +49,8 @@ public interface IntelliLangInjection {
     }
 
     @JacksonXmlProperty(localName = "place")
-    IntelliLangPlace place();
+    @JacksonXmlElementWrapper(useWrapping = false)
+    List<IntelliLangPlace> places();
 
     static ImmutableIntelliLangInjection.Builder builder() {
         return ImmutableIntelliLangInjection.builder();
@@ -61,7 +64,7 @@ public interface IntelliLangInjection {
         return builder()
                 .language(injection.getLanguage().get())
                 .displayName(displayName)
-                .place(IntelliLangPlace.of(injection.getPattern().get()))
+                .addPlaces(IntelliLangPlace.of(injection.getPattern().get()))
                 .build();
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangInjection.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration.intellilang;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.palantir.gradle.ideaconfiguration.LanguageInjection;
+import org.immutables.value.Value;
+
+/**
+ * Represents a single language injection rule in IntelliLang.xml.
+ */
+@Value.Immutable
+@JsonDeserialize(as = ImmutableIntelliLangInjection.class)
+public interface IntelliLangInjection {
+
+    @JacksonXmlProperty(isAttribute = true)
+    String language();
+
+    @JacksonXmlProperty(isAttribute = true, localName = "injector-id")
+    @Value.Default
+    default String injectorId() {
+        return "java";
+    }
+
+    @JacksonXmlProperty(localName = "display-name")
+    String displayName();
+
+    @JacksonXmlProperty(localName = "single-file")
+    @Value.Default
+    default IntelliLangSingleFile singleFile() {
+        return ImmutableIntelliLangSingleFile.builder().build();
+    }
+
+    @JacksonXmlProperty(localName = "place")
+    IntelliLangPlace place();
+
+    static ImmutableIntelliLangInjection.Builder builder() {
+        return ImmutableIntelliLangInjection.builder();
+    }
+
+    static IntelliLangInjection from(LanguageInjection injection) {
+        String displayName = injection.getDisplayName().isPresent()
+                ? injection.getDisplayName().get()
+                : injection.getName();
+
+        return builder()
+                .language(injection.getLanguage().get())
+                .displayName(displayName)
+                .place(IntelliLangPlace.of(injection.getPattern().get()))
+                .build();
+    }
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration.intellilang;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import org.immutables.value.Value;
+
+/**
+ * Place element containing PSI pattern for IntelliLang.xml.
+ */
+@Value.Immutable
+@JsonDeserialize(as = ImmutableIntelliLangPlace.class)
+public interface IntelliLangPlace {
+
+    @JacksonXmlText(value = true)
+    String pattern();
+
+    static ImmutableIntelliLangPlace.Builder builder() {
+        return ImmutableIntelliLangPlace.builder();
+    }
+
+    static IntelliLangPlace of(String pattern) {
+        return builder().pattern(pattern).build();
+    }
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
@@ -34,11 +34,7 @@ public interface IntelliLangPlace {
     @JacksonXmlCData
     String pattern();
 
-    static ImmutableIntelliLangPlace.Builder builder() {
-        return ImmutableIntelliLangPlace.builder();
-    }
-
     static IntelliLangPlace of(String pattern) {
-        return builder().pattern(pattern).build();
+        return ImmutableIntelliLangPlace.builder().pattern(pattern).build();
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.ideaconfiguration.intellilang;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 import org.immutables.value.Value;
@@ -25,6 +26,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(as = ImmutableIntelliLangPlace.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface IntelliLangPlace {
 
     @JacksonXmlText(value = true)

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangPlace.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.ideaconfiguration.intellilang;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlCData;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 import org.immutables.value.Value;
 
@@ -30,6 +31,7 @@ import org.immutables.value.Value;
 public interface IntelliLangPlace {
 
     @JacksonXmlText(value = true)
+    @JacksonXmlCData
     String pattern();
 
     static ImmutableIntelliLangPlace.Builder builder() {

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangProject.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangProject.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration.intellilang;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import org.immutables.value.Value;
+
+/**
+ * Root element for IntelliLang.xml configuration file.
+ */
+@Value.Immutable
+@JacksonXmlRootElement(localName = "project")
+@JsonDeserialize(as = ImmutableIntelliLangProject.class)
+public interface IntelliLangProject {
+
+    @JacksonXmlProperty(isAttribute = true)
+    String version();
+
+    @JacksonXmlProperty(localName = "component")
+    IntelliLangComponent component();
+
+    static ImmutableIntelliLangProject.Builder builder() {
+        return ImmutableIntelliLangProject.builder();
+    }
+
+    static IntelliLangProject of(IntelliLangComponent component, String version) {
+        return builder().component(component).version(version).build();
+    }
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangProject.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangProject.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.ideaconfiguration.intellilang;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -27,6 +28,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JacksonXmlRootElement(localName = "project")
 @JsonDeserialize(as = ImmutableIntelliLangProject.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface IntelliLangProject {
 
     @JacksonXmlProperty(isAttribute = true)

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangProject.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangProject.java
@@ -37,11 +37,10 @@ public interface IntelliLangProject {
     @JacksonXmlProperty(localName = "component")
     IntelliLangComponent component();
 
-    static ImmutableIntelliLangProject.Builder builder() {
-        return ImmutableIntelliLangProject.builder();
-    }
-
     static IntelliLangProject of(IntelliLangComponent component, String version) {
-        return builder().component(component).version(version).build();
+        return ImmutableIntelliLangProject.builder()
+                .component(component)
+                .version(version)
+                .build();
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangSingleFile.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangSingleFile.java
@@ -35,7 +35,7 @@ public interface IntelliLangSingleFile {
         return "false";
     }
 
-    static ImmutableIntelliLangSingleFile.Builder builder() {
-        return ImmutableIntelliLangSingleFile.builder();
+    static IntelliLangSingleFile defaultSingleFile() {
+        return ImmutableIntelliLangSingleFile.builder().build();
     }
 }

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangSingleFile.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangSingleFile.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.ideaconfiguration.intellilang;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import org.immutables.value.Value;
+
+/**
+ * Single-file configuration element for IntelliLang.xml.
+ */
+@Value.Immutable
+@JsonDeserialize(as = ImmutableIntelliLangSingleFile.class)
+public interface IntelliLangSingleFile {
+
+    @JacksonXmlProperty(isAttribute = true)
+    @Value.Default
+    default String value() {
+        return "false";
+    }
+
+    static ImmutableIntelliLangSingleFile.Builder builder() {
+        return ImmutableIntelliLangSingleFile.builder();
+    }
+}

--- a/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangSingleFile.java
+++ b/gradle-idea-configuration/src/main/java/com/palantir/gradle/ideaconfiguration/intellilang/IntelliLangSingleFile.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.ideaconfiguration.intellilang;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.immutables.value.Value;
@@ -25,6 +26,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(as = ImmutableIntelliLangSingleFile.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface IntelliLangSingleFile {
 
     @JacksonXmlProperty(isAttribute = true)

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/ConfigurationCacheTest.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/ConfigurationCacheTest.groovy
@@ -38,7 +38,7 @@ class ConfigurationCacheTest extends ConfigurationCacheSpec {
         """.stripIndent(true)
 
         expect:
-        runTasksWithConfigurationCacheAndCheck('classes', '-Didea.active=true')
+        runTasksWithConfigurationCacheAndCheck('classes', '-Didea.active=true', '-Didea.sync.active=true')
     }
 
     def "updateExternalDepsXml task runs with configuration cache"() {
@@ -54,6 +54,6 @@ class ConfigurationCacheTest extends ConfigurationCacheSpec {
         """.stripIndent(true)
 
         expect:
-        runTasksWithConfigurationCacheAndCheck('updateExternalDepsXml', '-Didea.active=true')
+        runTasksWithConfigurationCacheAndCheck('updateExternalDepsXml', '-Didea.active=true', '-Didea.sync.active=true')
     }
 }

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPluginIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/IdeaConfigurationPluginIntegrationSpec.groovy
@@ -35,7 +35,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we dont generate the config'
         def externalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -75,7 +75,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def externalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -109,7 +109,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def externalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -143,7 +143,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def externalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -187,7 +187,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         externalDepsFile.text = existing
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def newExternalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -230,7 +230,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         externalDepsFile.text = existing
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def newExternalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -274,7 +274,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         externalDepsFile.text = existing
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def newExternalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -318,7 +318,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         externalDepsFile.text = existing
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def newExternalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -360,7 +360,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         externalDepsFile.text = existing
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def newExternalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')
@@ -389,7 +389,7 @@ class IdeaConfigurationPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def externalDepsFile = new File(projectDir, '.idea/externalDependencies.xml')

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
@@ -40,7 +40,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we dont generate the config'
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
@@ -62,7 +62,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
@@ -104,7 +104,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true)
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config'
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
@@ -163,7 +163,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         intelliLangFile.text = existing
 
         when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'we generate the correct config with both injections'
         def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
@@ -215,7 +215,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true)
 
         when: 'we run the task'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'all patterns with same language and display name are merged into single injection with multiple place elements'
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
@@ -277,7 +277,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         intelliLangFile.text = existing
 
         when: 'we run the task'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'new patterns are merged with existing patterns into single injection'
         def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
@@ -352,7 +352,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true)
 
         when: 'we run the task'
-        runTasksSuccessfully('-Didea.active=true')
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
 
         then: 'complex patterns are properly merged by language and display name'
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
@@ -27,6 +27,10 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
+    private static void assertXmlEquals(String expected, String actual) {
+        assert expected.trim() == actual.trim()
+    }
+
     def 'nothing happens if no language injections defined'() {
         //language=gradle
         buildFile << '''
@@ -64,20 +68,20 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
         intelliLangFile.exists()
 
-        def xml = new XmlSlurper().parse(intelliLangFile)
-        xml.@version == '4'
-        xml.component.@name == 'LanguageInjectionConfiguration'
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="SQL" injector-id="java">
+                  <display-name>SqlExecutor.execute (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))</place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
 
-        def injection = xml.component.injection[0]
-        injection.@language == 'SQL'
-        injection.@'injector-id' == 'java'
-        injection.'display-name'.text() == 'SqlExecutor.execute (com.example)'
-        injection.'single-file'.@value == 'false'
-
-        def pattern = injection.place.text()
-        pattern.contains('psiParameter().ofMethod(0')
-        pattern.contains('.withName("execute")')
-        pattern.contains('.definedInClass("com.example.SqlExecutor")')
+        assertXmlEquals(expected, intelliLangFile.text)
     }
 
     def 'handles multiple language injections'() {
@@ -106,16 +110,25 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
         intelliLangFile.exists()
 
-        def xml = new XmlSlurper().parse(intelliLangFile)
-        xml.component.injection.size() == 2
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="HTML" injector-id="java">
+                  <display-name>HtmlRenderer.render (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))</place>
+                </injection>
+                <injection language="SQL" injector-id="java">
+                  <display-name>SqlExecutor.execute (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))</place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
 
-        def languages = xml.component.injection.@language*.text()
-        languages.contains('SQL')
-        languages.contains('HTML')
-
-        def displayNames = xml.component.injection.'display-name'*.text()
-        displayNames.contains('SqlExecutor.execute (com.example)')
-        displayNames.contains('HtmlRenderer.render (com.example)')
+        assertXmlEquals(expected, intelliLangFile.text)
     }
 
     def 'merges with existing IntelliLang.xml'() {
@@ -139,7 +152,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
               <injection language="RegExp" injector-id="java">
                 <display-name>Existing.pattern (com.example)</display-name>
                 <single-file value="false"/>
-                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))]]></place>
+                <place>psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))</place>
               </injection>
             </component>
           </project>
@@ -152,31 +165,94 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         when: 'we run the first time'
         runTasksSuccessfully('-Didea.active=true')
 
-        then: 'we generate the correct config'
+        then: 'we generate the correct config with both injections'
         def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
         newIntelliLangFile.exists()
 
-        def xml = new XmlSlurper().parse(newIntelliLangFile)
-        xml.component.injection.size() == 2
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="RegExp" injector-id="java">
+                  <display-name>Existing.pattern (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))</place>
+                </injection>
+                <injection language="SQL" injector-id="java">
+                  <display-name>SqlExecutor.execute (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))</place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
 
-        def languages = xml.component.injection.@language*.text()
-        languages.contains('SQL')
-        languages.contains('RegExp')
-
-        def displayNames = xml.component.injection.'display-name'*.text()
-        displayNames.contains('SqlExecutor.execute (com.example)')
-        displayNames.contains('Existing.pattern (com.example)')
+        assertXmlEquals(expected, newIntelliLangFile.text)
     }
 
-    def 'replaces injection with same display name'() {
+    def 'merges multiple patterns with same language and display name into single injection'() {
         //language=gradle
         buildFile << '''
             ideaConfiguration {
                 languageInjections {
-                    'sql-executor' {
+                    'sql-query-1' {
                         language = 'SQL'
-                        displayName = 'SqlExecutor.execute (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                        displayName = 'DatabaseLibrary (com.example.db)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("executeQuery").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))'
+                    }
+                    'sql-query-2' {
+                        language = 'SQL'
+                        displayName = 'DatabaseLibrary (com.example.db)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("executeUpdate").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))'
+                    }
+                    'sql-query-3' {
+                        language = 'SQL'
+                        displayName = 'DatabaseLibrary (com.example.db)'
+                        pattern = 'psiParameter().ofMethod(1, psiMethod().withName("prepareStatement").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the task'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'all patterns with same language and display name are merged into single injection with multiple place elements'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.exists()
+
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="SQL" injector-id="java">
+                  <display-name>DatabaseLibrary (com.example.db)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("executeQuery").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("executeUpdate").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(1, psiMethod().withName("prepareStatement").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))</place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
+
+        assertXmlEquals(expected, intelliLangFile.text)
+    }
+
+    def 'merges new patterns with existing patterns that have same language and display name'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-new-1' {
+                        language = 'SQL'
+                        displayName = 'SqlLibrary (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("newMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))'
+                    }
+                    'sql-new-2' {
+                        language = 'SQL'
+                        displayName = 'SqlLibrary (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("newMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))'
                     }
                 }
             }
@@ -186,10 +262,11 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         def existing = '''
           <project version="4">
             <component name="LanguageInjectionConfiguration">
-              <injection language="HTML" injector-id="java">
-                <display-name>SqlExecutor.execute (com.example)</display-name>
+              <injection language="SQL" injector-id="java">
+                <display-name>SqlLibrary (com.example)</display-name>
                 <single-file value="false"/>
-                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("old").withParameters("java.lang.String").definedInClass("com.example.Old"))]]></place>
+                <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
               </injection>
             </component>
           </project>
@@ -199,115 +276,112 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
         intelliLangFile.parentFile.mkdirs()
         intelliLangFile.text = existing
 
-        when: 'we run the first time'
+        when: 'we run the task'
         runTasksSuccessfully('-Didea.active=true')
 
-        then: 'we generate the correct config with new injection replacing old'
+        then: 'new patterns are merged with existing patterns into single injection'
         def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
         newIntelliLangFile.exists()
 
-        def xml = new XmlSlurper().parse(newIntelliLangFile)
-        xml.component.injection.size() == 1
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="SQL" injector-id="java">
+                  <display-name>SqlLibrary (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("newMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("newMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
 
-        def injection = xml.component.injection[0]
-        injection.@language == 'SQL'
-        injection.'display-name'.text() == 'SqlExecutor.execute (com.example)'
-        injection.place.text().contains('.withName("execute")')
-        !injection.place.text().contains('.withName("old")')
+        assertXmlEquals(expected, newIntelliLangFile.text)
     }
 
-    def 'uses name as display name if displayName not provided'() {
+    def 'complex merge with multiple languages and display names'() {
         //language=gradle
         buildFile << '''
             ideaConfiguration {
                 languageInjections {
-                    'my-sql-injection' {
+                    'xml-case-1' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("processXml").withParameters("java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'xml-case-2' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("queryWithArray").withParameters("java.lang.String", "int[]").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'xml-case-3' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("queryWithList").withParameters("java.lang.String", "java.util.List").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'xml-case-4' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'xml-case-5' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'xml-case-6' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'xml-case-7' {
+                        language = 'XML'
+                        displayName = 'EdgeCaseLibrary (com.example.edgecases)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                    }
+                    'sql-separate' {
                         language = 'SQL'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                        displayName = 'AnotherLibrary (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").definedInClass("com.example.AnotherLibrary"))'
                     }
                 }
             }
         '''.stripIndent(true)
 
-        when: 'we run the first time'
+        when: 'we run the task'
         runTasksSuccessfully('-Didea.active=true')
 
-        then: 'we generate the correct config'
+        then: 'complex patterns are properly merged by language and display name'
         def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
         intelliLangFile.exists()
 
-        def xml = new XmlSlurper().parse(intelliLangFile)
-        xml.component.injection[0].'display-name'.text() == 'my-sql-injection'
-    }
-
-    def 'keeps existing project version'() {
-        //language=gradle
-        buildFile << '''
-            ideaConfiguration {
-                languageInjections {
-                    'sql-executor' {
-                        language = 'SQL'
-                        displayName = 'SqlExecutor.execute (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
-                    }
-                }
-            }
-        '''.stripIndent(true)
-
         //language=xml
-        def existing = '''
-          <project version="3">
-            <component name="LanguageInjectionConfiguration"></component>
-          </project>
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="SQL" injector-id="java">
+                  <display-name>AnotherLibrary (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").definedInClass("com.example.AnotherLibrary"))</place>
+                </injection>
+                <injection language="XML" injector-id="java">
+                  <display-name>EdgeCaseLibrary (com.example.edgecases)</display-name>
+                  <single-file value="false"/>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("processXml").withParameters("java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("queryWithArray").withParameters("java.lang.String", "int[]").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("queryWithList").withParameters("java.lang.String", "java.util.List").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place>psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                </injection>
+              </component>
+            </project>
         '''.stripIndent(true).trim()
 
-        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
-        intelliLangFile.parentFile.mkdirs()
-        intelliLangFile.text = existing
-
-        when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
-
-        then: 'we keep the existing version'
-        def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
-        newIntelliLangFile.exists()
-
-        def xml = new XmlSlurper().parse(newIntelliLangFile)
-        xml.@version == '3'
-    }
-
-    def 'injections are sorted by display name'() {
-        //language=gradle
-        buildFile << '''
-            ideaConfiguration {
-                languageInjections {
-                    'z-last' {
-                        language = 'SQL'
-                        displayName = 'Z Last'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("z").definedInClass("com.example.Z"))'
-                    }
-                    'a-first' {
-                        language = 'HTML'
-                        displayName = 'A First'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("a").definedInClass("com.example.A"))'
-                    }
-                    'm-middle' {
-                        language = 'RegExp'
-                        displayName = 'M Middle'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("m").definedInClass("com.example.M"))'
-                    }
-                }
-            }
-        '''.stripIndent(true)
-
-        when: 'we run the first time'
-        runTasksSuccessfully('-Didea.active=true')
-
-        then: 'injections are sorted alphabetically'
-        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
-        def xml = new XmlSlurper().parse(intelliLangFile)
-
-        def displayNames = xml.component.injection.'display-name'*.text()
-        displayNames == ['A First', 'M Middle', 'Z Last']
+        assertXmlEquals(expected, intelliLangFile.text)
     }
 }

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
@@ -1,0 +1,313 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.ideaconfiguration
+
+import nebula.test.IntegrationSpec
+
+class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
+
+    def setup() {
+        //language=gradle
+        buildFile << '''
+            apply plugin: 'com.palantir.idea-configuration'
+            apply plugin: 'idea'
+        '''.stripIndent(true)
+    }
+
+    def 'nothing happens if no language injections defined'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                // no languageInjections defined
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we dont generate the config'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        !intelliLangFile.exists()
+    }
+
+    def 'plugin creates IntelliLang.xml file in the .idea folder'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-executor' {
+                        language = 'SQL'
+                        displayName = 'SqlExecutor.execute (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we generate the correct config'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.exists()
+
+        def xml = new XmlSlurper().parse(intelliLangFile)
+        xml.@version == '4'
+        xml.component.@name == 'LanguageInjectionConfiguration'
+
+        def injection = xml.component.injection[0]
+        injection.@language == 'SQL'
+        injection.@'injector-id' == 'java'
+        injection.'display-name'.text() == 'SqlExecutor.execute (com.example)'
+        injection.'single-file'.@value == 'false'
+
+        def pattern = injection.place.text()
+        pattern.contains('psiParameter().ofMethod(0')
+        pattern.contains('.withName("execute")')
+        pattern.contains('.definedInClass("com.example.SqlExecutor")')
+    }
+
+    def 'handles multiple language injections'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-executor' {
+                        language = 'SQL'
+                        displayName = 'SqlExecutor.execute (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                    }
+                    'html-renderer' {
+                        language = 'HTML'
+                        displayName = 'HtmlRenderer.render (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we generate the correct config'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.exists()
+
+        def xml = new XmlSlurper().parse(intelliLangFile)
+        xml.component.injection.size() == 2
+
+        def languages = xml.component.injection.@language*.text()
+        languages.contains('SQL')
+        languages.contains('HTML')
+
+        def displayNames = xml.component.injection.'display-name'*.text()
+        displayNames.contains('SqlExecutor.execute (com.example)')
+        displayNames.contains('HtmlRenderer.render (com.example)')
+    }
+
+    def 'merges with existing IntelliLang.xml'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-executor' {
+                        language = 'SQL'
+                        displayName = 'SqlExecutor.execute (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        //language=xml
+        def existing = '''
+          <project version="4">
+            <component name="LanguageInjectionConfiguration">
+              <injection language="RegExp" injector-id="java">
+                <display-name>Existing.pattern (com.example)</display-name>
+                <single-file value="false"/>
+                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))]]></place>
+              </injection>
+            </component>
+          </project>
+        '''.stripIndent(true).trim()
+
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.parentFile.mkdirs()
+        intelliLangFile.text = existing
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we generate the correct config'
+        def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        newIntelliLangFile.exists()
+
+        def xml = new XmlSlurper().parse(newIntelliLangFile)
+        xml.component.injection.size() == 2
+
+        def languages = xml.component.injection.@language*.text()
+        languages.contains('SQL')
+        languages.contains('RegExp')
+
+        def displayNames = xml.component.injection.'display-name'*.text()
+        displayNames.contains('SqlExecutor.execute (com.example)')
+        displayNames.contains('Existing.pattern (com.example)')
+    }
+
+    def 'replaces injection with same display name'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-executor' {
+                        language = 'SQL'
+                        displayName = 'SqlExecutor.execute (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        //language=xml
+        def existing = '''
+          <project version="4">
+            <component name="LanguageInjectionConfiguration">
+              <injection language="HTML" injector-id="java">
+                <display-name>SqlExecutor.execute (com.example)</display-name>
+                <single-file value="false"/>
+                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("old").withParameters("java.lang.String").definedInClass("com.example.Old"))]]></place>
+              </injection>
+            </component>
+          </project>
+        '''.stripIndent(true).trim()
+
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.parentFile.mkdirs()
+        intelliLangFile.text = existing
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we generate the correct config with new injection replacing old'
+        def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        newIntelliLangFile.exists()
+
+        def xml = new XmlSlurper().parse(newIntelliLangFile)
+        xml.component.injection.size() == 1
+
+        def injection = xml.component.injection[0]
+        injection.@language == 'SQL'
+        injection.'display-name'.text() == 'SqlExecutor.execute (com.example)'
+        injection.place.text().contains('.withName("execute")')
+        !injection.place.text().contains('.withName("old")')
+    }
+
+    def 'uses name as display name if displayName not provided'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'my-sql-injection' {
+                        language = 'SQL'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we generate the correct config'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.exists()
+
+        def xml = new XmlSlurper().parse(intelliLangFile)
+        xml.component.injection[0].'display-name'.text() == 'my-sql-injection'
+    }
+
+    def 'keeps existing project version'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-executor' {
+                        language = 'SQL'
+                        displayName = 'SqlExecutor.execute (com.example)'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        //language=xml
+        def existing = '''
+          <project version="3">
+            <component name="LanguageInjectionConfiguration"></component>
+          </project>
+        '''.stripIndent(true).trim()
+
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.parentFile.mkdirs()
+        intelliLangFile.text = existing
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'we keep the existing version'
+        def newIntelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        newIntelliLangFile.exists()
+
+        def xml = new XmlSlurper().parse(newIntelliLangFile)
+        xml.@version == '3'
+    }
+
+    def 'injections are sorted by display name'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'z-last' {
+                        language = 'SQL'
+                        displayName = 'Z Last'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("z").definedInClass("com.example.Z"))'
+                    }
+                    'a-first' {
+                        language = 'HTML'
+                        displayName = 'A First'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("a").definedInClass("com.example.A"))'
+                    }
+                    'm-middle' {
+                        language = 'RegExp'
+                        displayName = 'M Middle'
+                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("m").definedInClass("com.example.M"))'
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the first time'
+        runTasksSuccessfully('-Didea.active=true')
+
+        then: 'injections are sorted alphabetically'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        def xml = new XmlSlurper().parse(intelliLangFile)
+
+        def displayNames = xml.component.injection.'display-name'*.text()
+        displayNames == ['A First', 'M Middle', 'Z Last']
+    }
+}

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
@@ -75,7 +75,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                 <injection language="SQL" injector-id="java">
                   <display-name>SqlExecutor.execute (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))]]></place>
                 </injection>
               </component>
             </project>
@@ -117,12 +117,12 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                 <injection language="HTML" injector-id="java">
                   <display-name>HtmlRenderer.render (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))]]></place>
                 </injection>
                 <injection language="SQL" injector-id="java">
                   <display-name>SqlExecutor.execute (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))]]></place>
                 </injection>
               </component>
             </project>
@@ -152,7 +152,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
               <injection language="RegExp" injector-id="java">
                 <display-name>Existing.pattern (com.example)</display-name>
                 <single-file value="false"/>
-                <place>psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))</place>
+                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))]]></place>
               </injection>
             </component>
           </project>
@@ -176,12 +176,12 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                 <injection language="RegExp" injector-id="java">
                   <display-name>Existing.pattern (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("pattern").withParameters("java.lang.String").definedInClass("com.example.Existing"))]]></place>
                 </injection>
                 <injection language="SQL" injector-id="java">
                   <display-name>SqlExecutor.execute (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))]]></place>
                 </injection>
               </component>
             </project>
@@ -228,9 +228,9 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                 <injection language="SQL" injector-id="java">
                   <display-name>DatabaseLibrary (com.example.db)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("executeQuery").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("executeUpdate").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(1, psiMethod().withName("prepareStatement").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("executeQuery").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("executeUpdate").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("prepareStatement").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))]]></place>
                 </injection>
               </component>
             </project>
@@ -265,8 +265,8 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
               <injection language="SQL" injector-id="java">
                 <display-name>SqlLibrary (com.example)</display-name>
                 <single-file value="false"/>
-                <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
-                <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("existingMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))]]></place>
+                <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("existingMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))]]></place>
               </injection>
             </component>
           </project>
@@ -290,10 +290,10 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                 <injection language="SQL" injector-id="java">
                   <display-name>SqlLibrary (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("existingMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("newMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("newMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("existingMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("existingMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("newMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("newMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))]]></place>
                 </injection>
               </component>
             </project>
@@ -365,18 +365,18 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                 <injection language="SQL" injector-id="java">
                   <display-name>AnotherLibrary (com.example)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("execute").definedInClass("com.example.AnotherLibrary"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("execute").definedInClass("com.example.AnotherLibrary"))]]></place>
                 </injection>
                 <injection language="XML" injector-id="java">
                   <display-name>EdgeCaseLibrary (com.example.edgecases)</display-name>
                   <single-file value="false"/>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("processXml").withParameters("java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("queryWithArray").withParameters("java.lang.String", "int[]").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("queryWithList").withParameters("java.lang.String", "java.util.List").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
-                  <place>psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))</place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("processXml").withParameters("java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("queryWithArray").withParameters("java.lang.String", "int[]").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("queryWithList").withParameters("java.lang.String", "java.util.List").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
                 </injection>
               </component>
             </project>

--- a/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
+++ b/gradle-idea-configuration/src/test/groovy/com/palantir/gradle/ideaconfiguration/UpdateIntelliLangXmlIntegrationSpec.groovy
@@ -55,7 +55,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                     'sql-executor' {
                         language = 'SQL'
                         displayName = 'SqlExecutor.execute (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))']
                     }
                 }
             }
@@ -92,12 +92,12 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                     'sql-executor' {
                         language = 'SQL'
                         displayName = 'SqlExecutor.execute (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))']
                     }
                     'html-renderer' {
                         language = 'HTML'
                         displayName = 'HtmlRenderer.render (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("render").withParameters("java.lang.String").definedInClass("com.example.HtmlRenderer"))']
                     }
                 }
             }
@@ -139,7 +139,7 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                     'sql-executor' {
                         language = 'SQL'
                         displayName = 'SqlExecutor.execute (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.SqlExecutor"))']
                     }
                 }
             }
@@ -198,17 +198,17 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                     'sql-query-1' {
                         language = 'SQL'
                         displayName = 'DatabaseLibrary (com.example.db)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("executeQuery").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("executeQuery").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))']
                     }
                     'sql-query-2' {
                         language = 'SQL'
                         displayName = 'DatabaseLibrary (com.example.db)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("executeUpdate").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("executeUpdate").withParameters("java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))']
                     }
                     'sql-query-3' {
                         language = 'SQL'
                         displayName = 'DatabaseLibrary (com.example.db)'
-                        pattern = 'psiParameter().ofMethod(1, psiMethod().withName("prepareStatement").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(1, psiMethod().withName("prepareStatement").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.db.DatabaseLibrary"))']
                     }
                 }
             }
@@ -247,12 +247,12 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                     'sql-new-1' {
                         language = 'SQL'
                         displayName = 'SqlLibrary (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("newMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("newMethod1").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))']
                     }
                     'sql-new-2' {
                         language = 'SQL'
                         displayName = 'SqlLibrary (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("newMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("newMethod2").withParameters("java.lang.String").definedInClass("com.example.SqlLibrary"))']
                     }
                 }
             }
@@ -310,42 +310,42 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                     'xml-case-1' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("processXml").withParameters("java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("processXml").withParameters("java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'xml-case-2' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("queryWithArray").withParameters("java.lang.String", "int[]").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("queryWithArray").withParameters("java.lang.String", "int[]").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'xml-case-3' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("queryWithList").withParameters("java.lang.String", "java.util.List").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("queryWithList").withParameters("java.lang.String", "java.util.List").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'xml-case-4' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'xml-case-5' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'xml-case-6' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'xml-case-7' {
                         language = 'XML'
                         displayName = 'EdgeCaseLibrary (com.example.edgecases)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))']
                     }
                     'sql-separate' {
                         language = 'SQL'
                         displayName = 'AnotherLibrary (com.example)'
-                        pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute").definedInClass("com.example.AnotherLibrary"))'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("execute").definedInClass("com.example.AnotherLibrary"))']
                     }
                 }
             }
@@ -377,6 +377,96 @@ class UpdateIntelliLangXmlIntegrationSpec extends IntegrationSpec {
                   <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("queryWithPrimitives").withParameters("java.lang.String", "int", "long", "boolean", "double").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
                   <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("int", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
                   <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("EdgeCaseLibrary").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.edgecases.EdgeCaseLibrary"))]]></place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
+
+        assertXmlEquals(expected, intelliLangFile.text)
+    }
+
+    def 'single injection with multiple patterns in a list'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'sql-multi' {
+                        language = 'SQL'
+                        displayName = 'MultiPatternLibrary (com.example)'
+                        patterns = [
+                            'psiParameter().ofMethod(0, psiMethod().withName("query").withParameters("java.lang.String").definedInClass("com.example.MultiPatternLibrary"))',
+                            'psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.MultiPatternLibrary"))',
+                            'psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String").definedInClass("com.example.MultiPatternLibrary"))'
+                        ]
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the task'
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
+
+        then: 'all patterns from the list are included in a single injection with multiple place elements'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.exists()
+
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="SQL" injector-id="java">
+                  <display-name>MultiPatternLibrary (com.example)</display-name>
+                  <single-file value="false"/>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query").withParameters("java.lang.String").definedInClass("com.example.MultiPatternLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("execute").withParameters("java.lang.String").definedInClass("com.example.MultiPatternLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String").definedInClass("com.example.MultiPatternLibrary"))]]></place>
+                </injection>
+              </component>
+            </project>
+        '''.stripIndent(true).trim()
+
+        assertXmlEquals(expected, intelliLangFile.text)
+    }
+
+    def 'combines patterns from multiple injections and list patterns'() {
+        //language=gradle
+        buildFile << '''
+            ideaConfiguration {
+                languageInjections {
+                    'regexp-multi' {
+                        language = 'RegExp'
+                        displayName = 'PatternLibrary (com.example.patterns)'
+                        patterns = [
+                            'psiParameter().ofMethod(0, psiMethod().withName("match").withParameters("java.lang.String").definedInClass("com.example.patterns.PatternLibrary"))',
+                            'psiParameter().ofMethod(0, psiMethod().withName("find").withParameters("java.lang.String").definedInClass("com.example.patterns.PatternLibrary"))'
+                        ]
+                    }
+                    'regexp-single' {
+                        language = 'RegExp'
+                        displayName = 'PatternLibrary (com.example.patterns)'
+                        patterns = ['psiParameter().ofMethod(0, psiMethod().withName("replace").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.patterns.PatternLibrary"))']
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'we run the task'
+        runTasksSuccessfully('-Didea.active=true', '-Didea.sync.active=true')
+
+        then: 'all patterns are merged into single injection'
+        def intelliLangFile = new File(projectDir, '.idea/IntelliLang.xml')
+        intelliLangFile.exists()
+
+        //language=xml
+        def expected = '''
+            <project version="4">
+              <component name="LanguageInjectionConfiguration">
+                <injection language="RegExp" injector-id="java">
+                  <display-name>PatternLibrary (com.example.patterns)</display-name>
+                  <single-file value="false"/>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("find").withParameters("java.lang.String").definedInClass("com.example.patterns.PatternLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("match").withParameters("java.lang.String").definedInClass("com.example.patterns.PatternLibrary"))]]></place>
+                  <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("replace").withParameters("java.lang.String", "java.lang.String").definedInClass("com.example.patterns.PatternLibrary"))]]></place>
                 </injection>
               </component>
             </project>


### PR DESCRIPTION
## Before this PR
We had no centralized method to modify the `.idea/IntelliLang.xml` file for configuring IntelliJ language injections (SQL, HTML, RegExp, etc.) in string parameters.

## After this PR
Now we can update the `.idea/IntelliLang.xml` via the `languageInjections` extension:

```gradle
ideaConfiguration {
    languageInjections {
        'sql-executor' {
            language = 'SQL'
            displayName = 'SqlExecutor.execute (com.example)'
            pattern = 'psiParameter().ofMethod(0, psiMethod().withName("execute")...)'
        }
    }
}
```

or in java

```java
IdeaConfigurationExtension extension = rootProject.getExtensions().getByType(IdeaConfigurationExtension.class);
extension.getLanguageInjections().register("sql-executor", injection -> {
    injection.getLanguage().set("SQL");
    injection.getDisplayName().set("SqlExecutor.execute (com.example)");
    injection.getPattern().set("psiParameter().ofMethod(0, psiMethod().withName(\"execute\")...)");
});
```

This is useful as we want to build a plugin to automatically add lang injections for dependencies and it is sensible for this plugin to manage the `.idea/IntelliLang.xml` file

==COMMIT_MSG==
Add support for configuring IntelliJ language injections via Gradle
==COMMIT_MSG==

**Key features:**
- Automatically updates IntelliLang.xml on Gradle sync
- Merges with existing injections without overwriting manual configurations
- Combines multiple patterns with same language/display name into single injection

## Possible downsides?
- Automatically modifies `.idea/IntelliLang.xml` on every sync, which could conflict with manual IDE changes
- Adds another task to the Gradle startup sequence, potentially impacting sync performance